### PR TITLE
Update jwk-node-jose.py

### DIFF
--- a/jwk-node-jose.py
+++ b/jwk-node-jose.py
@@ -67,7 +67,7 @@ def create_token(headerAndPayload,sign):
     token = quote_plus(token)
     return token
 
-if(len(sys.argv)>0):
+if len(sys.argv) > 1:
     payload = bytes(str(sys.argv[1]).encode('ascii'))
     key_size = int(sys.argv[2])
 else:


### PR DESCRIPTION
Fixing:
```
Traceback (most recent call last):
  File "jwk-node-jose.py", line 71, in <module>
    payload = bytes(str(sys.argv[1]).encode('ascii'))
IndexError: list index out of range
```
When not providing any args.